### PR TITLE
Mejor common-lib de repositorios

### DIFF
--- a/common-lib/src/main/java/grupo5/common/repositories/AggregateRoot.java
+++ b/common-lib/src/main/java/grupo5/common/repositories/AggregateRoot.java
@@ -1,0 +1,7 @@
+package grupo5.common.repositories;
+
+import java.util.UUID;
+
+public interface AggregateRoot {
+  UUID id();
+}

--- a/common-lib/src/main/java/grupo5/common/repositories/CrudRepository.java
+++ b/common-lib/src/main/java/grupo5/common/repositories/CrudRepository.java
@@ -1,0 +1,21 @@
+package grupo5.common.repositories;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CrudRepository<T extends AggregateRoot> {
+  T save(T aggregate);
+
+  List<T> findAll();
+
+  Optional<T> findById(UUID id);
+
+  void delete(T aggregate);
+
+  boolean existsById(UUID id);
+
+  long count();
+
+  void deleteAll();
+}

--- a/common-lib/src/main/java/grupo5/common/repositories/CrudRepositoryEnMemoria.java
+++ b/common-lib/src/main/java/grupo5/common/repositories/CrudRepositoryEnMemoria.java
@@ -1,0 +1,66 @@
+package grupo5.common.repositories;
+
+import grupo5.common.exceptions.ErrorCatalog;
+import grupo5.common.exceptions.ValidationException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public abstract class CrudRepositoryEnMemoria<T extends AggregateRoot>
+    implements CrudRepository<T> {
+  protected final Map<UUID, T> storage = new ConcurrentHashMap<>();
+
+  @Override
+  public T save(T aggregate) {
+    if (aggregate == null) {
+      throw new ValidationException(ErrorCatalog.ARGUMENTO_NULO);
+    }
+    if (aggregate.id() == null) {
+      throw new ValidationException(ErrorCatalog.ARGUMENTO_NULO);
+    }
+    storage.put(aggregate.id(), aggregate);
+    return aggregate;
+  }
+
+  @Override
+  public List<T> findAll() {
+    return new ArrayList<>(storage.values());
+  }
+
+  @Override
+  public Optional<T> findById(UUID id) {
+    if (id == null) {
+      throw new ValidationException(ErrorCatalog.ARGUMENTO_NULO);
+    }
+    return Optional.ofNullable(storage.get(id));
+  }
+
+  @Override
+  public void delete(T aggregate) {
+    if (aggregate == null || aggregate.id() == null) {
+      throw new ValidationException(ErrorCatalog.ARGUMENTO_NULO);
+    }
+    storage.remove(aggregate.id());
+  }
+
+  @Override
+  public boolean existsById(UUID id) {
+    if (id == null) {
+      throw new ValidationException(ErrorCatalog.ARGUMENTO_NULO);
+    }
+    return storage.containsKey(id);
+  }
+
+  @Override
+  public long count() {
+    return storage.size();
+  }
+
+  @Override
+  public void deleteAll() {
+    storage.clear();
+  }
+}

--- a/common-lib/src/test/java/grupo5/common/repositories/CrudRepositoryEnMemoriaTest.java
+++ b/common-lib/src/test/java/grupo5/common/repositories/CrudRepositoryEnMemoriaTest.java
@@ -1,0 +1,104 @@
+package grupo5.common.repositories;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import grupo5.common.exceptions.ValidationException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CrudRepositoryEnMemoriaTest {
+
+  private TestRepository repository;
+
+  private record TestAggregate(UUID id, String name) implements AggregateRoot {
+    public TestAggregate(String name) {
+      this(UUID.randomUUID(), name);
+    }
+  }
+
+  private static class TestRepository extends CrudRepositoryEnMemoria<TestAggregate> {}
+
+  @BeforeEach
+  void setUp() {
+    repository = new TestRepository();
+  }
+
+  @Test
+  void testSaveYFindById() {
+    TestAggregate aggregate = new TestAggregate("Test Name");
+    repository.save(aggregate);
+
+    Optional<TestAggregate> found = repository.findById(aggregate.id());
+    assertTrue(found.isPresent());
+    assertEquals("Test Name", found.get().name());
+  }
+
+  @Test
+  void testFindAll() {
+    TestAggregate aggregate1 = new TestAggregate("Test 1");
+    TestAggregate aggregate2 = new TestAggregate("Test 2");
+    repository.save(aggregate1);
+    repository.save(aggregate2);
+
+    List<TestAggregate> all = repository.findAll();
+    assertEquals(2, all.size());
+    assertTrue(all.stream().anyMatch(a -> a.name().equals("Test 1")));
+    assertTrue(all.stream().anyMatch(a -> a.name().equals("Test 2")));
+  }
+
+  @Test
+  void testSaveNuloLanzaExcepcion() {
+    assertThrows(ValidationException.class, () -> repository.save(null));
+  }
+
+  @Test
+  void testSaveConIdNuloLanzaExcepcion() {
+    TestAggregate aggregateConIdNulo = new TestAggregate(null, "No Id");
+    assertThrows(ValidationException.class, () -> repository.save(aggregateConIdNulo));
+  }
+
+  @Test
+  void testFindByIdNuloLanzaExcepcion() {
+    assertThrows(ValidationException.class, () -> repository.findById(null));
+  }
+
+  @Test
+  void testExistsById() {
+    TestAggregate aggregate = new TestAggregate("Test Name");
+    assertFalse(repository.existsById(aggregate.id()));
+
+    repository.save(aggregate);
+    assertTrue(repository.existsById(aggregate.id()));
+  }
+
+  @Test
+  void testExistsByIdNuloLanzaExcepcion() {
+    assertThrows(ValidationException.class, () -> repository.existsById(null));
+  }
+
+  @Test
+  void testDelete() {
+    TestAggregate aggregate = new TestAggregate("Test Name");
+    repository.save(aggregate);
+    assertTrue(repository.existsById(aggregate.id()));
+
+    repository.delete(aggregate);
+    assertFalse(repository.existsById(aggregate.id()));
+    assertEquals(0, repository.count());
+  }
+
+  @Test
+  void testDeleteAll() {
+    TestAggregate aggregate1 = new TestAggregate("Test 1");
+    TestAggregate aggregate2 = new TestAggregate("Test 2");
+    repository.save(aggregate1);
+    repository.save(aggregate2);
+    assertEquals(2, repository.count());
+
+    repository.deleteAll();
+    assertEquals(0, repository.count());
+  }
+}


### PR DESCRIPTION
Para migrar un repositorio existente desde `BaseRepository` hacia `CrudRepository`, se deben seguir estos **4 pasos simples**:

---

### 1. Actualizar la Entidad de Dominio
La entidad de dominio debe actuar como la raíz del agregado:
* Implementar la interfaz `AggregateRoot`.
* Inicializar su identidad (`id`) de forma inmutable en el constructor (`this.id = UUID.randomUUID();`).
```java
public class Donante implements AggregateRoot {
    private final UUID id;

    public Donante(String nombre) {
        this.id = UUID.randomUUID(); // Identidad autogenerada nativamente
        this.nombre = nombre;
    }

    @Override
    public UUID getId() { return this.id; }
}
```

### 2. Cambiar la Declaración de la Interfaz del Repositorio
Heredar de `CrudRepository` parametrizado con la **entidad de dominio** en lugar del DTO:
* **Antes**: `public interface DonanteRepository extends BaseRepository<DonanteDTO>`
* **Ahora**: `public interface DonanteRepository extends CrudRepository<Donante>`

### 3. Cambiar la Clase de Infraestructura en Memoria
Modificar la clase que almacena los objetos en memoria para heredar de la nueva clase base genérica:
* **Antes**: `extends BaseRepositoryEnMemoria<DonanteDTO>`
* **Ahora**: `extends CrudRepositoryEnMemoria<Donante>`

### 4. Ajustar los Métodos de Invocación en los Servicios
Alinear las llamadas en los `Services` a las firmas limpias que no dependen de IDs en los parámetros:
* **Guardar**:
  * **Antes**: `repository.save(dto.getId(), dto);`
  * **Ahora**: `repository.save(donante);`
* **Eliminar**:
  * **Antes**: `repository.deleteById(id);`
  * **Ahora**: `repository.delete(donante);`